### PR TITLE
(ft-get-all-entries-api-endpoiny): consumes get all diary entries api…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -864,6 +864,14 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -872,20 +880,35 @@
       "optional": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
         "debug": "2.6.9",
         "depd": "1.1.2",
         "http-errors": "1.6.3",
-        "iconv-lite": "0.4.19",
+        "iconv-lite": "0.4.23",
         "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
         "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "brace-expansion": {
@@ -1733,6 +1756,59 @@
         "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
+        }
       }
     },
     "extend": {
@@ -2683,6 +2759,18 @@
         }
       }
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2786,6 +2874,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
@@ -3075,36 +3168,23 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "safer-buffer": "2.1.2"
           }
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
       }
     },
@@ -3340,6 +3420,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   },
   "homepage": "https://github.com/sulenchy/MyDiary#readme",
   "dependencies": {
+    "body-parser": "^1.18.3",
     "chai-http": "^4.0.0",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
+    "morgan": "^1.9.0",
     "winston": "^3.0.0"
   },
   "devDependencies": {

--- a/server/app.js
+++ b/server/app.js
@@ -1,20 +1,31 @@
 import express from 'express';
+import logger from 'morgan';
+import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import path from 'path';
 import winston from 'winston';
+import entriesRouter from './routes/entries.route';
 
 dotenv.config();
 
 const app = express();
 
+// parse application/x-www-form-urlencoded
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.text());
+app.use(bodyParser.json({ type: 'application/json' }));
+
+app.use(logger('dev'));
 
 const port = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname, '/public')));
 
-app.get('/', (req, res) => {
-  res.send('Hello World!!!');
-});
+app.use(logger('dev'));
+
+app.use('/api/v1', entriesRouter);
 
 
 app.listen(port, () => {

--- a/server/controllers/entries.controller.js
+++ b/server/controllers/entries.controller.js
@@ -1,0 +1,39 @@
+import entriesHelper from '../helpers/entries.helper';
+
+export default class entriesController {
+  static getAllEntries(req, res) {
+    entriesHelper.getAllEntries()
+      .then((entries) => {
+        if (Object.keys(entries).length === 0) {
+          return res.status(200)
+            .json({
+              data: {
+                entries,
+                message: 'No dairy entry available currently',
+              },
+              status: 'success',
+            });
+        }
+
+        return res.status(200)
+          .json({
+            data: {
+              entries,
+              message: 'Diary entries gotten successfully',
+            },
+            status: 'success',
+          });
+      })
+      .catch((err) => {
+        if (err) {
+          return res.status(404)
+            .json({
+              error: {
+                message: err.message,
+              },
+              status: 'fail',
+            });
+        }
+      });
+  }
+}

--- a/server/helpers/entries.helper.js
+++ b/server/helpers/entries.helper.js
@@ -1,0 +1,17 @@
+import dummyData from '../models/dummyData';
+
+
+export default class entriesHelper {
+  static getAllEntries() {
+    return new Promise((resolve, reject) => {
+      const data = dummyData.entries;
+      if (data) {
+        resolve(data);
+      } else {
+        reject({
+          message: 'Request unsuccessful',
+        });
+      }
+    });
+  }
+}

--- a/server/models/dummyData.js
+++ b/server/models/dummyData.js
@@ -55,5 +55,4 @@ const dummyData = {
   },
 };
 
-
 export default dummyData;

--- a/server/routes/entries.route.js
+++ b/server/routes/entries.route.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import entriesController from '../controllers/entries.controller';
+
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.status(200)
+    .send('Welcome to my Diary');
+});
+
+router.get('/entries', entriesController.getAllEntries);
+
+
+export default router;

--- a/server/test/entries.test.js
+++ b/server/test/entries.test.js
@@ -8,44 +8,6 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 describe('Diary Entries', () => {
-  beforeEach((done) => { // Before each test we empty the database
-    dummyData.entries = {};
-    done();
-  });
-
-  describe('Undefined or empty diary entries object', () => {
-    // it('it should return error message when entries object is undefined', (done) => {
-    //   dummyData.entries = undefined;
-    //   chai.request(app)
-    //     .get('/api/v1/entries')
-    //     .type('form')
-    //     .end((err, res) => {
-    //       expect(res).to.have(404);
-    //       expect(res.body).to.be.an('object');
-    //       expect(res.body).to.have.property('error');
-    //       expect(res.body.error.message).to.be.equal('Request unsucessful');
-    //       done();
-    //     });
-    // });
-
-    it('should GET empty diary entry when the entries object is {}', (done) => {
-      chai.request(app)
-        .get('/api/v1/entries')
-        .type('form')
-        .end((err, res) => {
-          expect(res).to.have(200);
-          expect(res.body).to.be.an('object');
-          expect(res.body).to.have.property('data');
-          expect(res.body.data).to.be.an('object');
-          expect(res.body.data).to.be.equal('{}');
-          expect(res.body).to.have.property('status');
-          expect(res.body.error.status).to.be.equal('fail');
-          expect(res.body.message).to.be.equal('No dairy entry available currently');
-          done();
-        });
-    });
-  });
-
   describe('/api/v1/entries', () => {
     it('it should POST a diary entry', (done) => {
       const entry = {
@@ -76,11 +38,11 @@ describe('Diary Entries', () => {
         .get('/api/v1/entries')
         .type('form')
         .end((err, res) => {
-          expect(res).to.have(200);
+          expect(res.status).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data)).to.have.lengthOf(1);
-          expect(res.body.message).to.be.equal('Request gotten sucessfully');
+          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
+          expect(res.body.data.message).to.be.equal('Diary entries gotten successfully');
           done();
         });
     });
@@ -100,7 +62,7 @@ describe('Diary Entries', () => {
           expect(res.status).to.equal(201);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(res.body.data).to.include({ userId: 3000 });
+          expect(res.body.data.entries).to.include({ userId: 3000 });
           expect(res.body.message).to.equal('New diary entry created successfully');
           done();
         });
@@ -111,11 +73,11 @@ describe('Diary Entries', () => {
         .get('/api/v1/entries')
         .type('form')
         .end((err, res) => {
-          expect(res).to.have(200);
+          expect(res.status).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data)).to.have.lengthOf(2);
-          expect(res.body.message).to.be.equal('Request gotten sucessfully');
+          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
+          expect(res.body.data.message).to.be.equal('Diary entries gotten successfully');
           done();
         });
     });
@@ -127,10 +89,10 @@ describe('Diary Entries', () => {
         .get('/api/v1/entries/1')
         .type('form')
         .end((err, res) => {
-          expect(res).to.have(200);
+          expect(res).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data)).to.have.lengthOf(1);
+          expect(Object.keys(res.body.data)).to.have.lengthOf(5);
           expect(res.body.message).to.be.equal('Request gotten sucessfully');
           done();
         });
@@ -141,7 +103,7 @@ describe('Diary Entries', () => {
         .get('/api/v1/entries/10')
         .type('form')
         .end((err, res) => {
-          expect(res.status).to.have(404);
+          expect(res.status).to.equal(404);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('status');
           expect(res.body.status).to.be.equal('fail');
@@ -167,6 +129,29 @@ describe('Diary Entries', () => {
           expect(res.body).to.have.property('data');
           expect(res.body.message).to.equal('request updated successfully');
           expect(res.body.status).to.be.equal('success');
+          done();
+        });
+    });
+  });
+
+  describe('Diary entries object', () => {
+    before((done) => { // Before each test we empty the database
+      dummyData.entries = {};
+      done();
+    });
+    it('should GET empty diary entry when the entries object is {}', (done) => {
+      chai.request(app)
+        .get('/api/v1/entries')
+        .type('form')
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body).to.have.ownPropertyDescriptor('data');
+          expect(res.body.data).to.be.an('object');
+          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(0);
+          expect(res.body).to.have.ownPropertyDescriptor('status');
+          expect(res.body.status).to.be.equal('success');
+          expect(res.body.data.message).to.be.equal('No dairy entry available currently');
           done();
         });
     });


### PR DESCRIPTION
… endpoint and test it

#### What does this PR do?
Consumes get-all-diary-entries api endpoint and also test it
[Developer should be able to get all diary entries via HTTP GET method](https://www.pivotaltracker.com/story/show/159058860)

##### Why are we doing this? Any context or related work?
To get get all diary entries 

#### Where should a reviewer start?
https://www.pivotaltracker.com/story/show/159058860

#### Manual testing steps?
- Run npm start
- open postman and hit https://localhost:8080/api/v1/entries

#### Screenshots
N/A
---

#### Database changes
N/a

#### Deployment instructions
N/A

#### New ENV variables
N/A