### PR TITLE
(ft-get-a-diary-api-endpoint):Adds get a diary entry api endpoint [Fi…

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import winston from 'winston';
 import entriesRouter from './routes/entries.route';
+import entriesController from './controllers/entries.controller';
 
 dotenv.config();
 
@@ -25,7 +26,15 @@ app.use(express.static(path.join(__dirname, '/public')));
 
 app.use(logger('dev'));
 
-app.use('/api/v1', entriesRouter);
+// app.use('/api/v1', entriesRouter);
+
+app.get('/me', (req, res) => {
+  res.send('Hello World!');
+});
+
+app.get('/api/v1/entries', entriesController.getAllEntries);
+
+app.get('/api/v1/entries/:id', entriesController.getDiaryEntryById);
 
 
 app.listen(port, () => {

--- a/server/controllers/entries.controller.js
+++ b/server/controllers/entries.controller.js
@@ -8,9 +8,9 @@ export default class entriesController {
           return res.status(200)
             .json({
               data: {
-                entries,
-                message: 'No dairy entry available currently',
+                entries,               
               },
+              message: 'No dairy entry available currently',
               status: 'success',
             });
         }
@@ -21,6 +21,34 @@ export default class entriesController {
               entries,
               message: 'Diary entries gotten successfully',
             },
+            message: 'Diary entries gotten successfully',
+            status: 'success',
+          });
+      })
+      .catch((err) => {
+        if (err) {
+          return res.status(404)
+            .json({
+              error: {
+                message: err.message,
+              },
+              status: 'fail',
+            });
+        }
+      });
+  }
+
+  static getDiaryEntryById(req, res) {
+    const { id } = req.params;
+    console.log(id);
+    entriesHelper.getDiaryEntryById(id)
+      .then((entry) => {
+        return res.status(200)
+          .json({
+            data: {
+              entry,
+            },
+            message: 'Diary entry gotten successfully',
             status: 'success',
           });
       })

--- a/server/helpers/entries.helper.js
+++ b/server/helpers/entries.helper.js
@@ -14,4 +14,23 @@ export default class entriesHelper {
       }
     });
   }
+
+  static getDiaryEntryById(entryId) {
+    return new Promise((resolve, reject) => {
+      // let data;
+      // Object.keys(dummyData.entries).filter((entry) => {
+      //   if (entry === entryId) {
+      //     data = dummyData.entries[entryId];
+      //   }
+      // });
+      const data = dummyData.entries[entryId];
+      if (data) {
+        resolve(data);
+      } else {
+        reject({
+          message: `Diary entry cannot be found`,
+        });
+      }
+    });
+  }
 }

--- a/server/routes/entries.route.js
+++ b/server/routes/entries.route.js
@@ -10,6 +10,6 @@ router.get('/', (req, res) => {
 });
 
 router.get('/entries', entriesController.getAllEntries);
-
+router.get('/entries/:id', entriesController.getDiaryEntryById);
 
 export default router;

--- a/server/test/entries.test.js
+++ b/server/test/entries.test.js
@@ -33,7 +33,7 @@ describe('Diary Entries', () => {
         });
     });
 
-    it('should GET entries object with one entry', (done) => {
+    it('should GET all entries in entries object', (done) => {
       chai.request(app)
         .get('/api/v1/entries')
         .type('form')
@@ -42,7 +42,7 @@ describe('Diary Entries', () => {
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
           expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
-          expect(res.body.data.message).to.be.equal('Diary entries gotten successfully');
+          expect(res.body.message).to.be.equal('Diary entries gotten successfully');
           done();
         });
     });
@@ -77,7 +77,7 @@ describe('Diary Entries', () => {
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
           expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
-          expect(res.body.data.message).to.be.equal('Diary entries gotten successfully');
+          expect(res.body.message).to.be.equal('Diary entries gotten successfully');
           done();
         });
     });
@@ -89,16 +89,16 @@ describe('Diary Entries', () => {
         .get('/api/v1/entries/1')
         .type('form')
         .end((err, res) => {
-          expect(res).to.equal(200);
+          expect(res.status).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data)).to.have.lengthOf(5);
-          expect(res.body.message).to.be.equal('Request gotten sucessfully');
+          expect(Object.keys(res.body.data)).to.have.lengthOf(1);
+          expect(res.body.message).to.be.equal('Diary entry gotten successfully');
           done();
         });
     });
 
-    it('should GET entries object with one entry', (done) => {
+    it('should not GET entry', (done) => {
       chai.request(app)
         .get('/api/v1/entries/10')
         .type('form')
@@ -151,7 +151,7 @@ describe('Diary Entries', () => {
           expect(Object.keys(res.body.data.entries)).to.have.lengthOf(0);
           expect(res.body).to.have.ownPropertyDescriptor('status');
           expect(res.body.status).to.be.equal('success');
-          expect(res.body.data.message).to.be.equal('No dairy entry available currently');
+          expect(res.body.message).to.be.equal('No dairy entry available currently');
           done();
         });
     });


### PR DESCRIPTION
…nishes #159058902]

#### What does this PR do?
Consumes get-a-diary-entry-api-endpoint
[Developer should be able to get a specific dairy entry via HTTP GET method](https://www.pivotaltracker.com/story/show/159058902)

##### Why are we doing this? Any context or related work?
To consume get-a-diary-entry-api-endpoint and make its tests pass

#### Where should a reviewer start?
https://www.pivotaltracker.com/story/show/159058902

#### Manual testing steps?
Run npm test

#### Screenshots
N/A
---

#### Database changes
N/A

#### Deployment instructions
N/A

#### New ENV variables
N/A