### PR TITLE
(ft-add-entry-api): consumes the post api endpoint [Finishes #159059012]

### DIFF
--- a/server/controllers/entries.controller.js
+++ b/server/controllers/entries.controller.js
@@ -8,7 +8,7 @@ export default class entriesController {
           return res.status(200)
             .json({
               data: {
-                entries,               
+                entries,
               },
               message: 'No dairy entry available currently',
               status: 'success',
@@ -41,13 +41,51 @@ export default class entriesController {
   static getDiaryEntryById(req, res) {
     const { id } = req.params;
     entriesHelper.getDiaryEntryById(id)
-      .then((entry) => {
-        return res.status(200)
+      .then((entry) => res.status(200)
           .json({
             data: {
               entry,
             },
             message: 'Diary entry gotten successfully',
+            status: 'success',
+          }))
+      .catch((err) => {
+        if (err) {
+          return res.status(404)
+            .json({
+              error: {
+                message: err.message,
+              },
+              status: 'fail',
+            });
+        }
+      });
+  }
+
+  static addNewDiaryEntry(req, res) {
+    const {
+      date,
+      time,
+      userId,
+      title,
+      description,
+    } = req.body;
+
+    entriesHelper.addNewDiaryEntry(date, time, userId, title, description)
+      .then((newEntry) => {
+        if (newEntry === undefined) {
+          return res.status(400)
+            .json({
+              message: 'Invalid diary entry',
+              status: 'fail',
+            });
+        }
+        return res.status(201)
+          .json({
+            data: {
+              Entry: newEntry,
+            },
+            message: 'New diary entry created successfully',
             status: 'success',
           });
       })

--- a/server/helpers/entries.helper.js
+++ b/server/helpers/entries.helper.js
@@ -22,7 +22,27 @@ export default class entriesHelper {
         resolve(data);
       } else {
         reject({
-          message: `Diary entry cannot be found`,
+          message: 'Diary entry cannot be found',
+        });
+      }
+    });
+  }
+
+  static addNewDiaryEntry(date, time, userId, title, description) {
+    return new Promise((resolve, reject) => {
+      dummyData.entries.push({
+        date,
+        time,
+        userId,
+        title,
+        description,
+      });
+      const data = dummyData.entries[dummyData.entries.length - 1];
+      if (data) {
+        resolve(data);
+      } else {
+        reject({
+          message: 'Sorry, New diary entry cannot be created',
         });
       }
     });

--- a/server/routes/entries.route.js
+++ b/server/routes/entries.route.js
@@ -11,5 +11,6 @@ router.get('/', (req, res) => {
 
 router.get('/entries', entriesController.getAllEntries);
 router.get('/entries/:id', entriesController.getDiaryEntryById);
+router.post('/entries', entriesController.addNewDiaryEntry);
 
 export default router;

--- a/server/test/entries.test.js
+++ b/server/test/entries.test.js
@@ -24,9 +24,9 @@ describe('Diary Entries', () => {
           expect(res.status).to.equal(201);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('status');
-          expect(res.body.message).to.equal('success');
+          expect(res.body.status).to.equal('success');
           expect(res.body).to.have.property('data');
-          expect(res.body.data).to.include({ userId: 1000 });
+          expect(res.body.data.Entry).to.include({ userId: 1000 });
           expect(res.body.data).to.be.an('object');
           expect(res.body.message).to.equal('New diary entry created successfully');
           done();
@@ -41,7 +41,7 @@ describe('Diary Entries', () => {
           expect(res.status).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
+          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(6);
           expect(res.body.message).to.be.equal('Diary entries gotten successfully');
           done();
         });
@@ -62,7 +62,8 @@ describe('Diary Entries', () => {
           expect(res.status).to.equal(201);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(res.body.data.entries).to.include({ userId: 3000 });
+          expect(res.body.status).to.equal('success');
+          expect(res.body.data.Entry).to.include({ userId: 3000 });
           expect(res.body.message).to.equal('New diary entry created successfully');
           done();
         });
@@ -76,7 +77,7 @@ describe('Diary Entries', () => {
           expect(res.status).to.equal(200);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('data');
-          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(5);
+          expect(Object.keys(res.body.data.entries)).to.have.lengthOf(7);
           expect(res.body.message).to.be.equal('Diary entries gotten successfully');
           done();
         });


### PR DESCRIPTION
#### What does this PR do?
Consumes the post api endpoint
[Developer should be able to add new diary entry via HTTP POST method](https://www.pivotaltracker.com/story/show/159059012)

##### Why are we doing this? Any context or related work?
To make the post related test pass

#### Where should a reviewer start?
https://www.pivotaltracker.com/story/show/159059012

#### Manual testing steps?
Run npm test

#### Screenshots
N/A

---

#### Database changes
N/A

#### Deployment instructions
N/A

#### New ENV variables
N/A